### PR TITLE
Modification de la texture des personnages

### DIFF
--- a/UltimatePenguinRampage/include/Joueur.h
+++ b/UltimatePenguinRampage/include/Joueur.h
@@ -10,8 +10,8 @@ class Joueur : public Personnage
 {
     public:
         // Constructeurs
-        Joueur(std::string cheminImage); // Initalise la position au centre de l'écran
-        Joueur(int posX, int posY, std::string cheminImage);
+        Joueur(); // Initalise la position au centre de l'écran
+        Joueur(int posX, int posY);
 
         void gererEvenement(); // Récupère un événement et vérifie si celui-ci modifie le Joueur
         void deplacer(); // Déplace le personnage
@@ -19,6 +19,8 @@ class Joueur : public Personnage
     private:
         int direction; // La direction actuelle
         int dirPrecedente; // La direction de la trame précédente
+
+        Texture m_sprites[8]; // Les différents sprites du Joueur
 
         enum {BAS, HAUT, DROITE, GAUCHE, BAS_GAUCHE, HAUT_GAUCHE, HAUT_DROITE, BAS_DROITE, IMMOBILE}; // Les directions que peut avoir le personnage
 };

--- a/UltimatePenguinRampage/include/Personnage.h
+++ b/UltimatePenguinRampage/include/Personnage.h
@@ -10,8 +10,8 @@ class Personnage
 {
     public:
         // Constructeurs
-        Personnage(std::string cheminImage); // Initialise la postion à (0,0)
-        Personnage(int posX, int posY, std::string cheminImage);
+        Personnage(); // Initialise la postion à (0,0)
+        Personnage(int posX, int posY);
         ~Personnage(); // Destructeur
 
         void subitDegats(int nbDegats); // Enlève de la vie au Personnage
@@ -19,14 +19,14 @@ class Personnage
         void gererEvenement(); // Gère les événements qui concernent le Personnage
         void render(); // Afficher le Personnage
 
-        Texture getSprite(); // Getter : retourne m_sprite
+        Texture* getSprite(); // Getter : retourne m_sprite
     protected:
         int m_posX;
         int m_posY;
         int m_pdv;
         int m_mana;
         bool m_vivant;
-        Texture m_sprite; // L'image du Personnage
+        Texture* m_sprite; // Pointeur sur la texture du Personnage
     private:
 
 };

--- a/UltimatePenguinRampage/include/Texture.h
+++ b/UltimatePenguinRampage/include/Texture.h
@@ -7,11 +7,14 @@
 class Texture
 {
     public:
-        Texture(std::string chemin); // Constructeur
+        // Constructeurs
+        Texture(); // Par défaut
+        Texture(std::string cheminImage); // Créé la texture avec l'image donnée
+
         ~Texture(); // Destructeur
 
         void liberer(); // Libère la texture (pour détruire ou en changer)
-        void charger(std::string chemin); // Charge la texture
+        void charger(std::string cheminImage); // Charge la texture
         void render(int x, int y); // Afficher la texture à la position
 
         int getLargeur(); // Getter : retourne m_largeur

--- a/UltimatePenguinRampage/src/Jeu.cpp
+++ b/UltimatePenguinRampage/src/Jeu.cpp
@@ -4,7 +4,7 @@
 
 // Construceur
 Jeu::Jeu() {
-    j1 = new Joueur("img/PBface.bmp");
+    j1 = new Joueur();
     start();
 }
 

--- a/UltimatePenguinRampage/src/Joueur.cpp
+++ b/UltimatePenguinRampage/src/Joueur.cpp
@@ -7,14 +7,26 @@
 const int VITESSE_JOUEUR = 3;
 const int VITESSE_ANGLE = VITESSE_JOUEUR * cos(M_PI_4);
 
-Joueur::Joueur(std::string cheminImage) : Personnage(cheminImage), direction(IMMOBILE), dirPrecedente(IMMOBILE)
+Joueur::Joueur() : Personnage(), direction(IMMOBILE), dirPrecedente(IMMOBILE)
 {
-    m_posX = (Utils::SCREEN_WIDTH - m_sprite.getLargeur()) / 2;
-    m_posY = (Utils::SCREEN_HEIGHT - m_sprite.getHauteur()) / 2;
+    // Chargement des 8 textures du Joueur
+    m_sprites[BAS] = *(new Texture("img/PBface.bmp"));
+    m_sprites[BAS_GAUCHE] = *(new Texture("img/PBbasgauche.bmp"));
+    m_sprites[GAUCHE] = *(new Texture("img/PBgauche.bmp"));
+    m_sprites[HAUT_GAUCHE] = *(new Texture("img/PBhautgauche.bmp"));
+    m_sprites[HAUT] = *(new Texture("img/PBdos.bmp"));
+    m_sprites[HAUT_DROITE] = *(new Texture("img/PBhautdroite.bmp"));
+    m_sprites[DROITE] = *(new Texture("img/PBdroite.bmp"));
+    m_sprites[BAS_DROITE] = *(new Texture("img/PBbasdroite.bmp"));
 
+    m_sprite = &m_sprites[BAS]; // Attribution de la première texture
+
+    // Positionnement du Joueur au centre de l'écran
+    m_posX = (Utils::SCREEN_WIDTH - m_sprite->getLargeur()) / 2;
+    m_posY = (Utils::SCREEN_HEIGHT - m_sprite->getHauteur()) / 2;
 }
 
-Joueur::Joueur(int posX, int posY, std::string cheminImage) : Personnage(posX, posY, cheminImage), direction(IMMOBILE), dirPrecedente(IMMOBILE)
+Joueur::Joueur(int posX, int posY) : Personnage(posX, posY), direction(IMMOBILE), dirPrecedente(IMMOBILE)
 {
 }
 
@@ -55,25 +67,16 @@ void Joueur::deplacer() {
         case BAS_DROITE: m_posY += VITESSE_ANGLE; m_posX += VITESSE_ANGLE; break;
     }
 
-    if(direction != dirPrecedente) { // Change le sprite si nécessaire
-        switch(direction) {
-            case BAS: m_sprite.charger("img/PBface.bmp"); break;
-            case BAS_GAUCHE: m_sprite.charger("img/PBbasgauche.bmp"); break;
-            case GAUCHE: m_sprite.charger("img/PBgauche.bmp"); break;
-            case HAUT_GAUCHE: m_sprite.charger("img/PBhautgauche.bmp"); break;
-            case HAUT: m_sprite.charger("img/PBdos.bmp"); break;
-            case HAUT_DROITE: m_sprite.charger("img/PBhautdroite.bmp"); break;
-            case DROITE: m_sprite.charger("img/PBdroite.bmp"); break;
-            case BAS_DROITE: m_sprite.charger("img/PBbasdroite.bmp"); break;
-        }
+    if((direction != dirPrecedente) && (direction != IMMOBILE)) { // Change le sprite si nécessaire
+        m_sprite = &m_sprites[direction];
     }
 
     dirPrecedente = direction;
 
     // Faudrait quand même pas qu'il sorte de l'écran ce pingouin
     if(m_posX < 0) { m_posX = 0; }
-    if(m_posX + m_sprite.getLargeur() > Utils::SCREEN_WIDTH) { m_posX = Utils::SCREEN_WIDTH - m_sprite.getLargeur(); }
+    if(m_posX + m_sprite->getLargeur() > Utils::SCREEN_WIDTH) { m_posX = Utils::SCREEN_WIDTH - m_sprite->getLargeur(); }
     if(m_posY < 0) { m_posY = 0; }
-    if(m_posY + m_sprite.getHauteur() > Utils::SCREEN_HEIGHT) { m_posY = Utils::SCREEN_HEIGHT - m_sprite.getHauteur(); }
+    if(m_posY + m_sprite->getHauteur() > Utils::SCREEN_HEIGHT) { m_posY = Utils::SCREEN_HEIGHT - m_sprite->getHauteur(); }
 
 }

--- a/UltimatePenguinRampage/src/Personnage.cpp
+++ b/UltimatePenguinRampage/src/Personnage.cpp
@@ -3,16 +3,17 @@
 #include "Personnage.h"
 #include "Utils.h"
 
-Personnage::Personnage(std::string cheminImage) : m_posX(0), m_posY(0), m_sprite(cheminImage)
+Personnage::Personnage() : m_posX(0), m_posY(0), m_sprite(NULL)
 {
 }
 
-Personnage::Personnage(int posX, int posY, std::string cheminImage) : m_posX(posX), m_posY(posY), m_sprite(cheminImage)
+Personnage::Personnage(int posX, int posY) : m_posX(posX), m_posY(posY), m_sprite(NULL)
 {
 }
 
 Personnage::~Personnage() {
-    m_sprite.liberer();
+    m_sprite->liberer();
+    delete m_sprite;
 }
 
 void Personnage::subitDegats(int nbDegats) {
@@ -22,9 +23,9 @@ void Personnage::utiliserArme() {
 
 }
 void Personnage::render() {
-    m_sprite.render(m_posX, m_posY);
+    m_sprite->render(m_posX, m_posY);
 }
 
-Texture Personnage::getSprite() {
+Texture* Personnage::getSprite() {
     return m_sprite;
 }

--- a/UltimatePenguinRampage/src/Texture.cpp
+++ b/UltimatePenguinRampage/src/Texture.cpp
@@ -3,9 +3,13 @@
 #include "Texture.h"
 #include "Utils.h"
 
-Texture::Texture(std::string chemin) : m_image(NULL), m_largeur(0), m_hauteur(0)
+Texture::Texture() : m_image(NULL), m_largeur(0), m_hauteur(0)
 {
-    charger(chemin);
+}
+
+Texture::Texture(std::string cheminImage) : m_image(NULL), m_largeur(0), m_hauteur(0)
+{
+    charger(cheminImage);
 }
 
 Texture::~Texture()
@@ -13,13 +17,13 @@ Texture::~Texture()
     liberer();
 }
 
-void Texture::charger(std::string chemin) {
+void Texture::charger(std::string cheminImage) {
     liberer(); // Liberation de la texture précédente
 
     SDL_Texture* nouvelleTexture = NULL;
-    SDL_Surface* imageChargee = SDL_LoadBMP(chemin.c_str()); // Chargement de l'image Bitmap
+    SDL_Surface* imageChargee = SDL_LoadBMP(cheminImage.c_str()); // Chargement de l'image Bitmap
     if(imageChargee == NULL) { // Gestion de l'échec du chargement de l'image
-        std::cout << "Erreur : L'image " << chemin << " n'a pas pu etre chargee." << std::endl;
+        std::cout << "Erreur : L'image " << cheminImage << " n'a pas pu etre chargee." << std::endl;
     } else {
         SDL_SetColorKey(imageChargee, SDL_TRUE, SDL_MapRGB(imageChargee->format, 255, 0, 255)); // Activation de la transparence
 


### PR DESCRIPTION
La texture des personnages est désormais un pointeur sur un objet
Texture. Cela permet, dans le cas du joueur par exemple, de charger
toutes les textures dans le constructeurs (et donc une seule fois
chacune) et ensuite de donner l'adresse de la texture au pointeur, au
lieu de charger le fichier à chaque changement d'apparence.
